### PR TITLE
fix: workshop 6.0.0 compat

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -12,6 +12,7 @@
 from typing import Tuple
 
 from ovos_bus_client.session import SessionManager, Session
+from ovos_bus_client.message import Message
 from ovos_utils import classproperty
 from ovos_utils.gui import can_use_gui
 from ovos_utils.log import LOG
@@ -63,7 +64,7 @@ class WikipediaSkill(OVOSSkill):
             "image": None,
         }
 
-        if session.session_id == "default":
+        if sess.session_id == "default":
             self.gui.show_animated_image("jumping.gif")
 
         self.speak_dialog("searching", {"query": query})
@@ -163,7 +164,7 @@ class WikipediaSkill(OVOSSkill):
         if image:
             self.session_results[sess.session_id]["image"] = image
 
-            if session.session_id == "default":
+            if sess.session_id == "default":
                 self.gui.show_image(image, title=title, fill='PreserveAspectFit',
                                     override_idle=20, override_animations=True)
         else:

--- a/__init__.py
+++ b/__init__.py
@@ -63,7 +63,8 @@ class WikipediaSkill(OVOSSkill):
             "image": None,
         }
 
-        self.gui.show_animated_image("jumping.gif")
+        if session.session_id == "default":
+            self.gui.show_animated_image("jumping.gif")
 
         self.speak_dialog("searching", {"query": query})
 
@@ -161,8 +162,10 @@ class WikipediaSkill(OVOSSkill):
         title = self.session_results[sess.session_id].get("title") or "Wikipedia"
         if image:
             self.session_results[sess.session_id]["image"] = image
-            self.gui.show_image(image, title=title, fill='PreserveAspectFit',
-                                override_idle=20, override_animations=True)
+
+            if session.session_id == "default":
+                self.gui.show_image(image, title=title, fill='PreserveAspectFit',
+                                    override_idle=20, override_animations=True)
         else:
             LOG.info(f"No image in {self.session_results[sess.session_id]}")
 
@@ -186,12 +189,17 @@ class WikipediaSkill(OVOSSkill):
         else:
             self.speak_dialog("thats all")
 
-    def stop(self):
-        self.gui.release()
+    def can_stop(self, message: Message) -> bool:
+        return False
 
-    def stop_session(self, sess):
-        if sess.session_id in self.session_results:
-            self.session_results.pop(sess.session_id)
+    def stop_session(self, session: Session) -> bool:
+        # called during global stop only
+        if session.session_id in self.session_results:
+            self.session_results.pop(session.session_id)
+            if session.session_id == "default":
+                self.gui.release()
+            return True
+        return False
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ovos-utils>=0.7.0,<1.0.0
-ovos_workshop>=3.4.0a1,<4.0.0
+ovos_workshop>=3.4.0a1,<7.0.0
 ovos-wikipedia-solver>=0.0.1,<1.0.0


### PR DESCRIPTION
now required to implement self.can_stop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved session management by restricting certain GUI elements and resource releases to the "default" session only.

- **Chores**
  - Expanded compatibility for the `ovos_workshop` package to allow newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->