### PR TITLE
fix: update version_file path in release workflows

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -16,7 +16,7 @@ jobs:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
-      version_file: 'version.py'
+      version_file: 'ovos_skill_wikipedia/version.py'
       publish_pypi: true
       publish_release: true
       sync_dev: true

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -19,7 +19,7 @@ jobs:
       MATRIX_TOKEN: ${{ secrets.MATRIX_TOKEN }}
     with:
       branch: 'dev'
-      version_file: 'version.py'
+      version_file: 'ovos_skill_wikipedia/version.py'
       update_changelog: true
       publish_prerelease: true
       propose_release: true


### PR DESCRIPTION
## Summary

- `version.py` is at `ovos_skill_wikipedia/version.py` (inside the package) not at repo root
- Release CI was failing with: `Could not find version file '../../package/version.py'`
- Fixes `release_workflow.yml` and `publish_stable.yml` to use the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)