### PR TITLE
chore: add ovoscope end2end intent-routing tests

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -11,4 +11,5 @@ jobs:
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: 'test'
-      test_path: 'test'
+      system_deps: 'swig libfann-dev'
+      test_path: 'test/unittests'

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,6 +11,6 @@ jobs:
     with:
       python_version: '3.11'
       coverage_source: 'ovos_skill_wikipedia'
-      test_path: 'test/'
+      test_path: 'test/unittests'
       install_extras: ''
       min_coverage: 0

--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -11,4 +11,7 @@ jobs:
     with:
       python_version: '3.11'
       install_extras: 'test'
+      require_adapt: true
+      require_padatious: true
+      system_deps: 'swig libfann-dev'
       test_path: 'test/end2end/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,16 @@ dependencies = [
     "ovos-wikipedia-plugin>=1.0.0a1,<2.0.0"
 ]
 
+[project.optional-dependencies]
+test = [
+    "pytest",
+    "pytest-timeout",
+    "ovoscope>=1.0.1a1",
+    "ovos-workshop>=8.3.0a1,<9.0.0",
+    "ovos-adapt-parser>=1.6.0a1,<2.0.0",
+    "ovos-padatious>=1.1.0a1,<2.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/OpenVoiceOS/ovos-skill-wikipedia"
 

--- a/test/end2end/test_intents_en_us.py
+++ b/test/end2end/test_intents_en_us.py
@@ -1,0 +1,73 @@
+"""End-to-end intent routing tests for the en-US locale.
+
+Each canonical utterance is fired through a real MiniCroft and asserted to
+route to the expected intent handler and produce a spoken response. The article
+text itself depends on live search results, so assertions cover the intent
+binding and the presence of a ``speak`` response, not the dialog content.
+"""
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovoscope import CaptureSession, get_minicroft
+
+SKILL_ID = "ovos-skill-wikipedia.openvoiceos"
+
+
+class TestWikipediaIntentsEnUS(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.minicroft = get_minicroft([SKILL_ID])
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.minicroft.stop()
+
+    def _run(self, text):
+        session = Session("test-session")
+        session.pipeline = [
+            "ovos-adapt-pipeline-plugin-high",
+            "ovos-padatious-pipeline-plugin-high",
+            "ovos-adapt-pipeline-plugin-medium",
+            "ovos-padatious-pipeline-plugin-medium",
+            "ovos-adapt-pipeline-plugin-low",
+        ]
+        utterance = Message(
+            "recognizer_loop:utterance",
+            {"utterances": [text], "lang": "en-US"},
+            {"session": session.serialize(), "source": "A", "destination": "B"},
+        )
+        capture = CaptureSession(self.minicroft)
+        capture.capture(utterance, timeout=30)
+        return capture.finish()
+
+    def _assert_intent(self, text, intent_file):
+        messages = self._run(text)
+        types = [m.msg_type for m in messages]
+        self.assertIn(f"{SKILL_ID}:{intent_file}", types)
+        self.assertTrue(any("speak" in t for t in types))
+
+    def test_search_wikipedia_for_query(self):
+        self._assert_intent("search wikipedia for the moon", "wiki.intent")
+
+    def test_tell_me_about_query_on_wiki(self):
+        self._assert_intent("tell me about the moon on wiki", "wiki.intent")
+
+    def test_look_up_query_on_wikipedia(self):
+        self._assert_intent("look up the moon on wikipedia", "wiki.intent")
+
+    def test_what_does_wikipedia_say_about_query(self):
+        self._assert_intent("what does wikipedia say about the moon", "wiki.intent")
+
+    def test_wiki_roulette(self):
+        self._assert_intent("wiki roulette", "wikiroulette.intent")
+
+    def test_play_wikipedia_roulette(self):
+        self._assert_intent("play wikipedia roulette", "wikiroulette.intent")
+
+    def test_random_wikipedia_page(self):
+        self._assert_intent("random wikipedia page", "wikiroulette.intent")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Auto-generated ovoscope intent-routing tests.

Covers Padatious intents (exact message-type assertions) and Adapt intents
(speak-response assertions). One test method per canonical utterance.

Generated by `tools/gen_ovoscope_tests.py` from the dataset at
`knowledge/datasets/ovoscope/test_dataset.jsonl`.

Run: `pytest test/end2end/ -v --timeout=60`