### PR TITLE
fix: allow ovos-workshop 9.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 keywords = ["ovos", "skill", "plugin"]
 dependencies = [
     "ovos-utils>=0.7.0,<1.0.0",
-    "ovos-workshop>=8.0.0,<9.0.0",
+    "ovos-workshop>=8.0.0,<10.0.0",
     "ovos-wikipedia-plugin>=1.0.0a1,<2.0.0"
 ]
 
@@ -23,7 +23,7 @@ test = [
     "pytest",
     "pytest-timeout",
     "ovoscope>=1.0.1a1",
-    "ovos-workshop>=8.3.0a1,<9.0.0",
+    "ovos-workshop>=8.3.0a1,<10.0.0",
     "ovos-adapt-parser>=1.6.0a1,<2.0.0",
     "ovos-padatious>=1.1.0a1,<2.0.0",
 ]


### PR DESCRIPTION
ovos-core 2.5.0a2 requires `ovos-workshop>=9.0.2a1`; this repo's `<9.0.0` cap is one of 24 blocking the auto-generated constraints-alpha from resolving latest workshop (caught by raspOVOS's new Tier 2 `pip check` gate, which found shipped images with a broken dep graph). Cap bumped to `<10.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)