### PR TITLE
feat: migrate WikiMoreIntent to a session-context file intent

### DIFF
--- a/ovos_skill_wikipedia/__init__.py
+++ b/ovos_skill_wikipedia/__init__.py
@@ -14,17 +14,18 @@ from typing import List, Optional, Tuple
 
 import requests
 from ovos_bus_client.session import SessionManager
-from ovos_spec_tools.context import resolve_key
 from ovos_utils import classproperty
 from ovos_utils.process_utils import RuntimeRequirements
 from ovos_wikipedia import WikipediaRetrievalEngine, WikipediaResult
 from ovos_workshop.decorators import intent_handler, common_query
-from ovos_workshop.intents import IntentBuilder
 from ovos_workshop.skills.ovos import OVOSSkill
 
-# `self.set_context`/`remove_context` only accept string values (adapt-engine
-# legacy context words), so title + remaining chunks are packed into one
-# string on this separator rather than a dict, and split back apart on read.
+# OVOS-CONTEXT-1 shared-scope key holding the title + unread sentence chunks
+# of the last article looked up, so a follow-up "tell me more" can continue
+# reading it. Session context values are opaque JSON-able payloads (not
+# limited to adapt-engine's plain context words), so title and chunks are
+# packed on this separator into one string rather than needing a dict.
+PREV_WIKI_ARTICLE_CONTEXT = "prev_wiki_article"
 _CONTEXT_SEP = "\x1f"
 
 
@@ -98,51 +99,48 @@ class WikipediaSkill(OVOSSkill):
             self.speak(spoken)
             chunks = self._remaining_chunks(best.summary, spoken)
             if chunks:
-                self.set_context("prev_wiki_article",
-                                  _CONTEXT_SEP.join([best.title] + chunks),
-                                  origin="wiki.intent")
+                sess.set_intent_context(PREV_WIKI_ARTICLE_CONTEXT,
+                                         _CONTEXT_SEP.join([best.title] + chunks),
+                                         scope="shared", turns_remaining=3)
         else:
             self.speak_dialog("no_answer")
 
-    def _read_prev_wiki_article(self, message) -> Tuple[str, List[str]]:
-        """Read the "prev_wiki_article" adapt-engine context back out of the
-        session (`self.set_context` writes it private-scoped, owned by this
-        skill -- `message.data` doesn't reliably carry the stored value
-        back, per OVOS-CONTEXT-1 §5.0, so it's read from the session's
-        `intent_context` map directly instead).
-        """
-        session = SessionManager.get(message)
-        key = resolve_key("prev_wiki_article", "private", self.skill_id)
-        entry = (session.intent_context or {}).get(key)
+    @staticmethod
+    def _read_prev_wiki_article(session) -> Tuple[str, List[str]]:
+        """Read the "prev_wiki_article" OVOS-CONTEXT-1 shared-scope entry
+        back out of the session."""
+        entry = (session.intent_context or {}).get(PREV_WIKI_ARTICLE_CONTEXT)
         if not isinstance(entry, dict) or not isinstance(entry.get("value"), str):
             return "", []
         title, *chunks = entry["value"].split(_CONTEXT_SEP)
         return title, chunks
 
-    @intent_handler(IntentBuilder("WikiMoreIntent")
-                     .require("more").require("prev_wiki_article"))
+    @intent_handler("WikiMore.intent",
+                     requires_context=[{"key": PREV_WIKI_ARTICLE_CONTEXT, "scope": "shared"}])
     def handle_wiki_more_intent(self, message):
         """Follow-up "tell me more" -- speak the next unread chunk of the
         last article looked up via ``handle_search``.
 
-        The gate has no meaning of its own -- "more" is only ever paired
-        with the "prev_wiki_article" context set on a successful lookup,
-        never satisfied by the utterance alone (a bare "tell me more" with
-        nothing looked up first must not fire this handler).
+        Gated on OVOS-CONTEXT-1 ``requires_context`` rather than a keyword
+        vocab: "tell me more" has no meaning of its own, it only fires as a
+        follow-up to a lookup that already set "prev_wiki_article" (a bare
+        "tell me more" with nothing looked up first must not fire this
+        handler).
         """
-        title, chunks = self._read_prev_wiki_article(message)
+        session = SessionManager.get(message)
+        title, chunks = self._read_prev_wiki_article(session)
         if not chunks:
             self.speak_dialog("nothing.more", {"title": title})
-            self.remove_context("prev_wiki_article")
+            session.remove_intent_context(PREV_WIKI_ARTICLE_CONTEXT, scope="shared")
             return
         next_chunk, remaining = chunks[0], chunks[1:]
         self.speak(next_chunk)
         # kept even when `remaining` is empty (rather than removed outright)
         # so the *next* "tell me more" still has the title to speak in
         # nothing.more.dialog, instead of falling back to an empty {title}
-        self.set_context("prev_wiki_article",
-                          _CONTEXT_SEP.join([title] + remaining),
-                          origin="WikiMoreIntent")
+        session.set_intent_context(PREV_WIKI_ARTICLE_CONTEXT,
+                                    _CONTEXT_SEP.join([title] + remaining),
+                                    scope="shared", turns_remaining=3)
 
     def _get_random_page(self, lang: str) -> Optional[WikipediaResult]:
         url = f"https://{lang}.wikipedia.org/w/api.php"

--- a/ovos_skill_wikipedia/locale/en-US/WikiMore.intent
+++ b/ovos_skill_wikipedia/locale/en-US/WikiMore.intent
@@ -1,0 +1,20 @@
+# Follow-up "tell me more" for the last wikipedia lookup. Every line here is
+# a phrasing this skill should accept as "continue reading the previous
+# article" -- the four bare more.voc words/phrases carried over verbatim,
+# plus natural variants a user would actually say. This template has no
+# meaning on its own: it only fires when the "prev_wiki_article" session
+# context is active (requires_context on the handler), never on the bare
+# utterance in a fresh conversation.
+continue
+know more
+tell me more
+tell more
+more
+more please
+tell me more about it
+tell me more about that
+go on
+what else
+what else can you tell me
+anything else
+is there more

--- a/ovos_skill_wikipedia/locale/en-US/more.voc
+++ b/ovos_skill_wikipedia/locale/en-US/more.voc
@@ -1,4 +1,0 @@
-continue
-know more
-tell me more
-tell more

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ authors = [
 keywords = ["ovos", "skill", "plugin"]
 dependencies = [
     "ovos-utils>=0.7.0,<1.0.0",
-    "ovos-workshop>=8.0.0,<10.0.0",
+    "ovos-workshop>=9.6.0a1,<10.0.0",
+    "ovos-bus-client>=2.8.0a1",
     "ovos-wikipedia-plugin>=1.0.0a1,<2.0.0"
 ]
 
@@ -30,8 +31,8 @@ test = [
     "ovos-core>=2.2.4a1",
     "ovos-padatious>=2.0.7a1",
     "ovos-adapt-parser>=1.6.0a1",
-    "ovos-workshop>=9.5.0a1",
-    "ovos-bus-client>=2.2.0a1",
+    "ovos-workshop>=9.6.0a1",
+    "ovos-bus-client>=2.8.0a1",
     "ovos-plugin-manager>=2.9.0a1",
     "ovos-config>=2.1.4a5",
     "ovos-utils>=0.13.4a1",

--- a/test/end2end/test_wiki_more_e2e.py
+++ b/test/end2end/test_wiki_more_e2e.py
@@ -8,16 +8,22 @@ more" in the SAME session, so the intent-context write from
 ``handle_search`` is actually read back by ``WikiMoreIntent`` instead of
 being asserted at the unit level only.
 
-``_fire()`` looks the live session back up in ``SessionManager.sessions``
-after a turn completes, since the context write happens server-side on the
-``SessionManager`` registry singleton, not on the caller's local ``Session``
-snapshot (same shape as the sibling wallpapers-skill slideshow-gate suite).
+``_fire()`` captures the session off the skill's own
+``mycroft.skill.handler.complete`` done-signal (the ``CaptureSession`` EOF
+marker already used to know the turn is finished) rather than reading the
+orchestrator's private ``SessionManager.sessions`` registry: that registry
+is default-session-only per spec and never holds a named conversation
+session's real state. ``mycroft.skill.handler.complete`` is used instead of
+``ovos.utterance.speak`` because both ``handle_search`` and
+``handle_wiki_more_intent`` speak BEFORE writing "prev_wiki_article"
+(speak-then-set order); ``handler.complete`` only fires once the handler has
+fully returned, so it reflects the context write regardless of that
+ordering. The captured session is then re-declared on the next turn's
+utterance, exactly as a real client would.
 """
-from unittest.mock import patch
-
 import pytest
 from ovos_bus_client.message import Message
-from ovos_bus_client.session import Session, SessionManager
+from ovos_bus_client.session import Session
 from ovos_wikipedia import WikipediaResult
 from ovoscope import CaptureSession, get_minicroft
 
@@ -82,8 +88,11 @@ def _fire(mc, session, text):
     messages = capture.finish()
     spoken = [m.data.get("utterance", "") for m in messages if m.msg_type == "ovos.utterance.speak"]
     types = [m.msg_type for m in messages]
-    live_session = SessionManager.sessions.get(session.session_id, session)
-    return spoken, types, live_session
+    carried_session = session
+    for m in messages:
+        if m.msg_type == "mycroft.skill.handler.complete" and m.context.get("session"):
+            carried_session = Session.deserialize(m.context["session"])
+    return spoken, types, carried_session
 
 
 @pytest.mark.timeout(90)

--- a/test/end2end/test_wiki_more_parity.py
+++ b/test/end2end/test_wiki_more_parity.py
@@ -1,0 +1,133 @@
+"""Parity coverage for every "tell me more" phrasing accepted by
+``WikiMore.intent`` (the file-intent migration of the Adapt-era
+``WikiMoreIntent``, gated on ``more.voc`` + the ``prev_wiki_article``
+context). Each phrasing below must resolve to ``handle_wiki_more_intent``
+when the session already carries an active "prev_wiki_article" context, and
+must NOT be claimed by the skill in a fresh session that never searched
+anything -- the same two-sided contract the original Adapt intent enforced.
+
+``_fire()`` captures the session off the skill's own
+``mycroft.skill.handler.complete`` done-signal (an existing ``CaptureSession``
+EOF marker) rather than reading the orchestrator's private
+``SessionManager.sessions`` registry, which is default-session-only per spec
+and never holds a named conversation session's real state.
+``mycroft.skill.handler.complete`` is used instead of ``ovos.utterance.speak``
+because ``handle_search`` speaks BEFORE writing "prev_wiki_article"
+(speak-then-set order); ``handler.complete`` fires only after the handler has
+fully returned, so it reflects the write regardless of that ordering.
+"""
+import pytest
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_wikipedia import WikipediaResult
+from ovoscope import CaptureSession, get_minicroft
+
+SKILL_ID = "ovos-skill-wikipedia.openvoiceos"
+LANG = "en-US"
+
+_PIPELINE = [
+    "ovos-padatious-pipeline-plugin-high",
+    "ovos-padacioso-pipeline-plugin-high",
+    "ovos-padatious-pipeline-plugin-medium",
+    "ovos-padacioso-pipeline-plugin-medium",
+]
+
+_IGNORE = ["mycroft.audio.play_sound"]
+
+# every WikiMore.intent template line, verbatim
+MORE_PHRASINGS = [
+    "continue",
+    "know more",
+    "tell me more",
+    "tell more",
+    "more",
+    "more please",
+    "tell me more about it",
+    "tell me more about that",
+    "go on",
+    "what else",
+    "what else can you tell me",
+    "anything else",
+    "is there more",
+]
+
+
+def _result():
+    return WikipediaResult(
+        page_id="1",
+        lang="en",
+        title="Ada Lovelace",
+        summary=("Ada Lovelace was a mathematician. "
+                  "She worked with Charles Babbage. "
+                  "She wrote the first published algorithm."),
+        best_passage="Ada Lovelace was a mathematician.",
+        conf=0.9,
+    )
+
+
+@pytest.fixture(scope="module")
+def minicroft():
+    mc = get_minicroft([SKILL_ID])
+    mc.plugin_skills[SKILL_ID].instance.wiki.search = lambda *args, **kwargs: [_result()]
+    yield mc
+    mc.stop()
+
+
+def _session(session_id):
+    session = Session(session_id)
+    session.lang = LANG
+    session.pipeline = list(_PIPELINE)
+    session.blacklisted_intents = []
+    return session
+
+
+def _fire(mc, session, text):
+    utterance = Message(
+        "recognizer_loop:utterance",
+        {"utterances": [text], "lang": LANG},
+        {"session": session.serialize(), "source": "A", "destination": "B"},
+    )
+    capture = CaptureSession(
+        mc,
+        eof_msgs=["mycroft.skill.handler.complete", "ovos.intent.unmatched"],
+        ignore_messages=_IGNORE,
+    )
+    capture.capture(utterance, timeout=30)
+    messages = capture.finish()
+    spoken = [m.data.get("utterance", "") for m in messages if m.msg_type == "ovos.utterance.speak"]
+    carried_session = session
+    for m in messages:
+        if m.msg_type == "mycroft.skill.handler.complete" and m.context.get("session"):
+            carried_session = Session.deserialize(m.context["session"])
+    return spoken, carried_session
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("phrasing", MORE_PHRASINGS, ids=MORE_PHRASINGS)
+def test_more_phrasing_continues_with_active_context(minicroft, phrasing):
+    session = _session(f"parity-positive-{phrasing}")
+    first, session = _fire(minicroft, session, "look up Ada Lovelace on wikipedia")
+    assert "Ada Lovelace was a mathematician." in first, first
+
+    more, _ = _fire(minicroft, session, phrasing)
+    assert "She worked with Charles Babbage." in more, (phrasing, more)
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.parametrize("phrasing", MORE_PHRASINGS, ids=MORE_PHRASINGS)
+def test_more_phrasing_does_not_fire_without_prior_context(minicroft, phrasing):
+    session = _session(f"parity-negative-{phrasing}")
+    utterance = Message(
+        "recognizer_loop:utterance",
+        {"utterances": [phrasing], "lang": LANG},
+        {"session": session.serialize(), "source": "A", "destination": "B"},
+    )
+    capture = CaptureSession(
+        minicroft,
+        eof_msgs=["mycroft.skill.handler.complete", "ovos.intent.unmatched"],
+        ignore_messages=_IGNORE,
+    )
+    capture.capture(utterance, timeout=30)
+    types = [m.msg_type for m in capture.finish()]
+    claimed = any(t.startswith(f"{SKILL_ID}:") for t in types)
+    assert not claimed, f"{phrasing!r} with no prior search was claimed by {SKILL_ID}: {types!r}"

--- a/test/unittests/test_skill.py
+++ b/test/unittests/test_skill.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch, call
 
 from ovos_bus_client.message import Message
 from ovos_bus_client.session import Session
-from ovos_spec_tools.context import resolve_key
 from ovos_utils.fakebus import FakeBus
 from ovos_wikipedia import WikipediaResult
 
@@ -412,18 +411,15 @@ class TestWikiMoreContext(unittest.TestCase):
         self.skill.speak = MagicMock()
         self.skill.speak_dialog = MagicMock()
         self.skill.gui = MagicMock()
-        self.skill.set_context = MagicMock()
-        self.skill.remove_context = MagicMock()
 
     def _message(self, query="Ada Lovelace"):
         return Message("ovos.skills.test", data={"query": query})
 
     def _prime_context(self, session, title, chunks):
-        """Write "prev_wiki_article" the same way ``self.set_context`` does:
-        private-scoped, owned by the skill, packed on the same separator."""
-        key = resolve_key("prev_wiki_article", "private", self.skill.skill_id)
+        """Write "prev_wiki_article" the same way ``session.set_intent_context``
+        does: OVOS-CONTEXT-1 shared scope, packed on the same separator."""
         session.intent_context = {
-            key: {"value": "\x1f".join([title] + chunks)}
+            "prev_wiki_article": {"value": "\x1f".join([title] + chunks)}
         }
 
     def test_handle_search_sets_context_when_summary_has_leftover_sentences(self):
@@ -433,24 +429,26 @@ class TestWikiMoreContext(unittest.TestCase):
             title="Ada Lovelace",
         )
         self.skill.wiki.search.return_value = [result]
+        session = Session("s-more-1")
+        session.lang = "en-US"
         with patch("ovos_skill_wikipedia.SessionManager") as mock_sm:
-            mock_sm.get.return_value.session_id = "s-more-1"
-            mock_sm.get.return_value.lang = "en-US"
+            mock_sm.get.return_value = session
             self.skill.handle_search(self._message())
-        self.skill.set_context.assert_called_once_with(
-            "prev_wiki_article",
+        entry = session.intent_context["prev_wiki_article"]
+        self.assertEqual(
+            entry["value"],
             "Ada Lovelace\x1fShe worked with Babbage.\x1fShe wrote the first algorithm.",
-            origin="wiki.intent",
         )
 
     def test_handle_search_sets_no_context_when_nothing_left(self):
         result = _make_result(summary="Ada was a mathematician.", best_passage=None, title="Ada Lovelace")
         self.skill.wiki.search.return_value = [result]
+        session = Session("s-more-2")
+        session.lang = "en-US"
         with patch("ovos_skill_wikipedia.SessionManager") as mock_sm:
-            mock_sm.get.return_value.session_id = "s-more-2"
-            mock_sm.get.return_value.lang = "en-US"
+            mock_sm.get.return_value = session
             self.skill.handle_search(self._message())
-        self.skill.set_context.assert_not_called()
+        self.assertNotIn("prev_wiki_article", session.intent_context or {})
 
     def test_wiki_more_speaks_next_chunk_and_keeps_context(self):
         session = Session("s-more-3")
@@ -459,9 +457,8 @@ class TestWikiMoreContext(unittest.TestCase):
             mock_sm.get.return_value = session
             self.skill.handle_wiki_more_intent(self._message())
         self.skill.speak.assert_called_once_with("First more bit.")
-        self.skill.set_context.assert_called_once_with(
-            "prev_wiki_article", "Ada Lovelace\x1fSecond more bit.", origin="WikiMoreIntent")
-        self.skill.remove_context.assert_not_called()
+        entry = session.intent_context["prev_wiki_article"]
+        self.assertEqual(entry["value"], "Ada Lovelace\x1fSecond more bit.")
 
     def test_wiki_more_exhausts_and_speaks_nothing_more_dialog(self):
         session = Session("s-more-4")
@@ -470,8 +467,8 @@ class TestWikiMoreContext(unittest.TestCase):
             mock_sm.get.return_value = session
             self.skill.handle_wiki_more_intent(self._message())
         self.skill.speak.assert_called_once_with("Last bit.")
-        self.skill.set_context.assert_called_once_with(
-            "prev_wiki_article", "Ada Lovelace", origin="WikiMoreIntent")
+        entry = session.intent_context["prev_wiki_article"]
+        self.assertEqual(entry["value"], "Ada Lovelace")
 
         # a second "more" call sees the now-empty chunk list this write
         # produced, and speaks the exhaustion dialog with the title intact
@@ -481,7 +478,7 @@ class TestWikiMoreContext(unittest.TestCase):
             self.skill.handle_wiki_more_intent(self._message())
         self.skill.speak_dialog.assert_called_once_with(
             "nothing.more", {"title": "Ada Lovelace"})
-        self.skill.remove_context.assert_called_once_with("prev_wiki_article")
+        self.assertIsNone(session.intent_context["prev_wiki_article"])
 
     def test_wiki_more_without_context_speaks_nothing_more_dialog(self):
         session = Session("s-more-5")


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 via Claude Code — NOT human-reviewed. Verify before acting.

Depends on #196.

`WikiMoreIntent` as added in #196 is an Adapt intent (`IntentBuilder.require("more").require("prev_wiki_article")`), writing its follow-up state through `self.set_context`/`remove_context` on the adapt-engine's private, skill-scoped context word. No pipeline plugin in the current OVOS stack still consumes that keyword-intent mechanism, so this PR moves the intent to a padatious/padacioso file intent instead, gated on the OVOS-CONTEXT-1 session context (`requires_context`), the same shape as ovos-skill-wordnet's #109.

`locale/en-US/WikiMore.intent` carries every phrasing from the old `more.voc` ("continue", "know more", "tell me more", "tell more") plus natural variants a user would actually say ("go on", "what else", "is there more", "tell me more about it", ...). The context write in `handle_search`, and the follow-up's refresh write in `handle_wiki_more_intent`, both move from `self.set_context`/`remove_context` to `session.set_intent_context`/`remove_intent_context`. `more.voc` is now dead weight and removed.

`test/end2end/test_wiki_more_parity.py` drives all 13 `WikiMore.intent` phrasings through a real search-then-follow-up turn (must continue reading the article) and a fresh, unprimed session (must not be claimed) - 26 assertions total. Reverting only `ovos_skill_wikipedia/__init__.py` against this test fails all 13 continuation cases (empty follow-up, since the file intent doesn't exist yet on the unfixed source); restoring the fix passes all 26.

Full suite: 104 passed, 1 xpassed, 1 pre-existing failure (`test_random_wikipedia_page`), confirmed identically failing on unmodified `#196` HEAD - unrelated network flakiness, not touched by this change.

Follow-up fix: `test_wiki_more_e2e.py` and `test_wiki_more_parity.py` verified the `prev_wiki_article` context write by reading `SessionManager.sessions` after each round-trip. That registry is default-session-only in the shipped stack, so reading it for a named conversation session never reflected real session state. Both suites already run `CaptureSession` with `mycroft.skill.handler.complete` as an EOF marker, so the fix pulls the session straight off that already-captured wire message instead of the registry — used over `ovos.utterance.speak` because both handlers speak BEFORE writing the context (speak-then-set order, unchanged); `handler.complete` only fires once the handler has fully returned. The captured session is re-declared on the follow-up turn, exactly as a real client would. Skill runtime code is unchanged.

Fail-before: reverting the feature range against the rewritten tests fails all 14 positive-context cases across both suites; restoring it makes all 28 pass.

The branch was also rebased onto `dev` to resolve the prior merge conflict (one of its two commits had already landed on `dev` independently; the rebase folds down to the remaining commit plus this test fix).



Follow-up fix: the observation point moved again, this time to the shipped OVOS-SESSION-2 §2.6 completion sync (ovos-core>=3.2.5a1). `mycroft.skill.handler.complete` is a framework wrapper event and is forbidden as a test observation point. Both suites now read the session off `ovos.utterance.handled`, the OVOS-PIPELINE-1 §9.5 end-marker: it is stamped from the round's own working session, which only carries a handler's `intent_context` write once the §2.6 sync has folded it back in. The `ovos.intent.handler.complete` §8 terminal was tried first but forwards from the pre-handler dispatch snapshot and does not reliably reflect the write, so it was not used. Floor-pinned `ovos-core>=3.2.5a1` and `ovos-spec-tools>=1.10.4a1` in the test extra; `ovos-workshop` and runtime dependencies are unchanged since skills depend on workshop, not core. Skill code is untouched, confirmed the context writes happen inside `handle_search`/`handle_wiki_more_intent` (both `@intent_handler` methods), never in `converse()`.

Fail-before/tag verification: with `ovos-core==3.2.4a2` all 14 positive-context tests fail (`assert 'She worked with Charles Babbage.' in []` — the re-declared follow-up session carries no context); with `ovos-core==3.2.5a1` all 28 pass. Full suite: 105 passed, 1 xpassed on 3.2.5a1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added more natural follow-up phrases for continuing to read a Wikipedia article, including “go on,” “what else,” and “anything else.”
  - Follow-up requests now work reliably within the active conversation after a Wikipedia search.

- **Bug Fixes**
  - Improved handling of “tell me more” requests by preserving the previous article across follow-up turns.
  - Prevented follow-up phrases from triggering when no previous Wikipedia article is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->