### PR TITLE
feat: sv-SE locale parity

### DIFF
--- a/ovos_skill_wikipedia/locale/sv-SE/WikiMore.intent
+++ b/ovos_skill_wikipedia/locale/sv-SE/WikiMore.intent
@@ -1,0 +1,13 @@
+fortsätt
+vet mer
+berätta mer
+säg mer
+mer
+mer tack
+berätta mer om det
+berätta mer om detta
+kör på
+vad mer
+vad mer kan du berätta för mig
+något mer
+finns det mer

--- a/ovos_skill_wikipedia/locale/sv-SE/misc_blacklist.voc
+++ b/ovos_skill_wikipedia/locale/sv-SE/misc_blacklist.voc
@@ -1,0 +1,9 @@
+kan du
+förklara
+hur
+hur länge
+installera
+är det
+skills
+vad är klockan
+gör du

--- a/ovos_skill_wikipedia/locale/sv-SE/no entry found.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/no entry found.dialog
@@ -1,0 +1,2 @@
+Jag kan inte hitta någon relaterad Wikipedia-artikel
+Jag är rädd att det inte finns någon artikel om det

--- a/ovos_skill_wikipedia/locale/sv-SE/no_query.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/no_query.dialog
@@ -1,0 +1,2 @@
+Vem eller vad vill du att jag ska slå upp på Wikipedia?
+Vad ska jag söka efter på Wikipedia?

--- a/ovos_skill_wikipedia/locale/sv-SE/nothing.more.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/nothing.more.dialog
@@ -1,0 +1,2 @@
+det är allt jag har om {title}
+det är allt Wikipedia ger mig om {title}

--- a/ovos_skill_wikipedia/locale/sv-SE/pronoun.voc
+++ b/ovos_skill_wikipedia/locale/sv-SE/pronoun.voc
@@ -1,0 +1,4 @@
+(han|hon|den|det|de)
+(honom|henne|dem)
+(hans|hennes|dess|deras)
+(det|detta|de|dessa)

--- a/ovos_skill_wikipedia/locale/sv-SE/searching.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/searching.dialog
@@ -1,0 +1,2 @@
+Jag kollar Wikipedia efter {query}
+Låt mig slå upp {query} på Wikipedia

--- a/ovos_skill_wikipedia/locale/sv-SE/skill.json
+++ b/ovos_skill_wikipedia/locale/sv-SE/skill.json
@@ -1,0 +1,23 @@
+{
+  "skill_id": "ovos-skill-wikipedia.openvoiceos",
+  "source": "https://github.com/OpenVoiceOS/ovos-skill-wikipedia",
+  "name": "Wikipedia",
+  "description": "Fråga Wikipedia om svar på alla dina frågor. Få bara en sammanfattning, eller be om mer för fördjupad information.",
+  "examples": [
+    "Berätta om Elon Musk",
+    "Berätta om bönor",
+    "Kolla Wikipedia efter bönor",
+    "Berätta om Pembroke Welsh Corgi",
+    "Sök efter choklad",
+    "Mer information",
+    "Berätta mer"
+  ],
+  "tags": [
+    "wikipedia",
+    "uppslagsverk",
+    "allmänbildning",
+    "wiki",
+    "fråga",
+    "sökning"
+  ]
+}

--- a/ovos_skill_wikipedia/locale/sv-SE/thats all.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/thats all.dialog
@@ -1,0 +1,2 @@
+Det är allt jag kan hitta
+Det är allt jag vet

--- a/ovos_skill_wikipedia/locale/sv-SE/weather.voc
+++ b/ovos_skill_wikipedia/locale/sv-SE/weather.voc
@@ -1,0 +1,2 @@
+meteorologi
+väder

--- a/ovos_skill_wikipedia/locale/sv-SE/wiki.intent
+++ b/ovos_skill_wikipedia/locale/sv-SE/wiki.intent
@@ -1,0 +1,13 @@
+kan du hitta {query} på (wiki|wikipedia)
+kolla (wiki|wikipedia) efter {query}
+hitta detaljer om {query} (på|i) (wiki|wikipedia)
+ge mig information om {query} från (wiki|wikipedia)
+[snälla] slå upp {query} (på|i) (wiki|wikipedia)
+sök (wiki|wikipedia) efter [detaljer om] {query}
+berätta om {query} (på|från) (wiki|wikipedia)
+vad säger (wiki|wikipedia) (om|angående) {query}
+vad är känt om {query} på (wiki|wikipedia)
+vad är (wiki|wikipedia)-artikeln för {query}
+vad står det på (wiki|wikipedia) om {query}
+vem (är|var) {query} (på|enligt) (wiki|wikipedia)
+(wiki|wikipedia) {query}

--- a/ovos_skill_wikipedia/locale/sv-SE/wikiroulette.dialog
+++ b/ovos_skill_wikipedia/locale/sv-SE/wikiroulette.dialog
@@ -1,0 +1,2 @@
+kunskapsroulette aktiverad
+spelar wikipediaroulette

--- a/ovos_skill_wikipedia/locale/sv-SE/wikiroulette.intent
+++ b/ovos_skill_wikipedia/locale/sv-SE/wikiroulette.intent
@@ -1,0 +1,4 @@
+(visa|öppna) [en] slumpmässig (wiki|wikipedia) [sida]
+spela [wiki|wikipedia] roulette
+slumpmässig (wiki|wikipedia) [sida]
+(wiki|wikipedia) roulette


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

Adds the sv-SE locale, translated from the en-US reference (13 files: misc_blacklist.voc, "no entry found.dialog", no_query.dialog, nothing.more.dialog, pronoun.voc, searching.dialog, skill.json, "thats all.dialog", weather.voc, wiki.intent, WikiMore.intent, wikiroulette.dialog, wikiroulette.intent).

These lines were written by a machine; fix or delete any line a speaker would not say.

No low-confidence locales in this batch (sv-SE is native-standard confidence).

Proofs:
- `comm -3` between en-US and sv-SE file lists: empty.
- padacioso: sv-SE has 3 .intent files, 30 lines, 0 errors.
- `git diff origin/dev --name-only` outside `locale/sv-SE/`: empty.
- `git diff origin/dev --stat` tail: 13 files changed, 80 insertions(+).


**Parity after this PR**

1 of 15 locales have exactly the en-US file set.
The locales added by this PR (sv-SE) are complete.
All of ca-ES, da-DK, de-DE, es-ES, eu-ES, fr-FR, gl-ES, it-IT, kab, nl-NL, pl-PL, pt-BR, pt-PT, ru-RU lack pronoun.voc.
- ca-ES: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- da-DK: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- de-DE: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog; extra: more.voc
- es-ES: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- eu-ES: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json; extra: more.voc
- fr-FR: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- gl-ES: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- it-IT: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json; extra: more.voc
- kab: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json, weather.voc, wikiroulette.dialog
- nl-NL: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json; extra: more.voc
- pl-PL: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json, weather.voc, wiki.intent, WikiMore.intent, wikiroulette.intent
- pt-BR: lacks no_query.dialog, nothing.more.dialog; extra: more.voc
- pt-PT: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json; extra: more.voc
- ru-RU: lacks misc_blacklist.voc, no_query.dialog, nothing.more.dialog, skill.json, weather.voc; extra: more.voc
Files missing from locales that existed before this PR are left for a follow-up; nothing existing was edited.
