### PR TITLE
fix: repair intent lines with localised slot names or broken syntax

### DIFF
--- a/ovos_skill_wikipedia/locale/eu-ES/wikiroulette.intent
+++ b/ovos_skill_wikipedia/locale/eu-ES/wikiroulette.intent
@@ -1,5 +1,5 @@
-(erakutsi|bistaratu|ireki wiki ausaz
-(erakutsi|bistaratu|ireki wikipedia ausaz
+(erakutsi|bistaratu|ireki) wiki ausaz
+(erakutsi|bistaratu|ireki) wikipedia ausaz
 erreproduzitu wiki erruleta
 erreproduzitu wikipedia erruleta
 wiki ausaz


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

These lines never matched. A template that fails to parse under the OVOS-INTENT-1 grammar contributes nothing and produces no warning at load time.

eu-ES `wikiroulette.intent` had two lines with an unbalanced opening parenthesis: `(erakutsi|bistaratu|ireki wiki ausaz` and `(erakutsi|bistaratu|ireki wikipedia ausaz` — the alternation group was never closed, so the parser cannot resolve it. Both are balanced the way the file's other lines are shaped, closing the group right after the last alternative: `(erakutsi|bistaratu|ireki) wiki ausaz` and `(erakutsi|bistaratu|ireki) wikipedia ausaz`. No wording changed.

This template carries no slots, so there is no code-lookup line to report for this repo.

Checker (`ovos_spec_tools.expansion.expand` per line with sibling `.voc` files loaded, plus a foreign-slot scan against the en-US slot set `{query}`) over the whole `ovos_skill_wikipedia/locale/` tree:

- Before: `TOTAL_LINES=1282 CLASS_A=2 CLASS_B=0`
- After: `TOTAL_LINES=1282 CLASS_A=0 CLASS_B=0`

Unit tests: `pytest test -q -x --ignore=test/end2end` → 48 passed.
