### PR TITLE
translate(da-DK): add missing no_query/nothing.more dialogs + pronoun.voc, remove dead more.voc

### DIFF
--- a/ovos_skill_wikipedia/locale/da-DK/more.voc
+++ b/ovos_skill_wikipedia/locale/da-DK/more.voc
@@ -1,4 +1,0 @@
-fortsæt
-fortæl mig mere
-fortæll mere
-vide mere

--- a/ovos_skill_wikipedia/locale/da-DK/no_query.dialog
+++ b/ovos_skill_wikipedia/locale/da-DK/no_query.dialog
@@ -1,0 +1,2 @@
+Hvem eller hvad skal jeg slå op på Wikipedia?
+Hvad skal jeg søge efter på Wikipedia?

--- a/ovos_skill_wikipedia/locale/da-DK/nothing.more.dialog
+++ b/ovos_skill_wikipedia/locale/da-DK/nothing.more.dialog
@@ -1,0 +1,2 @@
+det er alt hvad jeg har om {title}
+det er alt hvad Wikipedia giver mig om {title}

--- a/ovos_skill_wikipedia/locale/da-DK/pronoun.voc
+++ b/ovos_skill_wikipedia/locale/da-DK/pronoun.voc
@@ -1,0 +1,9 @@
+# Anaforiske pronominer og påpegende ord: de står i stedet for en person
+# eller ting nævnt tidligere i samtalen, aldrig for en artikeltitel. Tjekket
+# af WikipediaSkill._is_anaphoric (nøjagtigt match, aldrig delstreng) før en
+# {query}-værdi slås op, så en rigtig titel der blot indeholder et af disse
+# ord ("Det Hvide Hus", "Hendes Majestæt") aldrig bliver afvist.
+(han|hun|den|det|de)
+(ham|hende|dem)
+(hans|hendes|dens|dets|deres)
+(den|det|dette|denne|disse)


### PR DESCRIPTION
Three files were missing entirely:
- `no_query.dialog` (spoken when the `{query}` slot is empty/unresolved)
- `nothing.more.dialog` (spoken when WikiMoreIntent has nothing further to add for `{title}`)
- `pronoun.voc` (loaded via `self.voc_list('pronoun', lang)` in `_is_anaphoric`, gates the `{query}` slot against bare anaphoric pronouns — verified functionally: "det"/"ham"/"dette" are correctly rejected, while multi-word titles that merely contain a pronoun word ("Det Hvide Hus", "hendes majestæt") are correctly *not* rejected, since the check is exact-match not substring)

Removed `more.voc`: not referenced anywhere in the code (grepped the whole package), and its 4 lines are the exact "four bare more.voc words/phrases carried over verbatim" the en-US `WikiMore.intent`'s own comment describes as already migrated into that file — it's dead content left over from before `WikiMoreIntent` existed, same pattern as a similar cleanup on ovos-skill-wolfie.

Validated with `ovos-localize-cli`: 0 errors for da-DK.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Danish prompts for requesting a Wikipedia search.
  - Added Danish responses for cases where no further information is available.
  - Improved Danish handling of pronouns and references in follow-up searches.

- **Updates**
  - Removed several Danish phrases previously recognized as requests for more information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->